### PR TITLE
Add gamepad viewer using HTML5 gamepad API

### DIFF
--- a/gamepad.js
+++ b/gamepad.js
@@ -1,0 +1,43 @@
+let canvas, ctx;
+
+function init() {
+    canvas = document.getElementById('gamepadCanvas');
+    ctx = canvas.getContext('2d');
+    window.addEventListener('gamepadconnected', onGamepadConnected);
+    window.addEventListener('gamepaddisconnected', onGamepadDisconnected);
+}
+
+function onGamepadConnected(event) {
+    console.log('Gamepad connected:', event.gamepad);
+    update();
+}
+
+function onGamepadDisconnected(event) {
+    console.log('Gamepad disconnected:', event.gamepad);
+}
+
+function update() {
+    const gamepads = navigator.getGamepads();
+    if (!gamepads) return;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    for (let i = 0; i < gamepads.length; i++) {
+        const gp = gamepads[i];
+        if (!gp) continue;
+
+        ctx.fillText(`Gamepad ${gp.index}: ${gp.id}`, 10, 30 * (i + 1));
+        for (let j = 0; j < gp.buttons.length; j++) {
+            const button = gp.buttons[j];
+            ctx.fillText(`Button ${j}: ${button.pressed}`, 10, 30 * (i + 1) + 20 * (j + 1));
+        }
+        for (let j = 0; j < gp.axes.length; j++) {
+            const axis = gp.axes[j];
+            ctx.fillText(`Axis ${j}: ${axis.toFixed(2)}`, 10, 30 * (i + 1) + 20 * (gp.buttons.length + j + 1));
+        }
+    }
+
+    requestAnimationFrame(update);
+}
+
+window.onload = init;

--- a/index.html
+++ b/index.html
@@ -7,5 +7,7 @@
     </head>
     <body>
         HelloWorld
+        <canvas id="gamepadCanvas" width="800" height="600"></canvas>
+        <script src="gamepad.js"></script>
     </body>
 </html>


### PR DESCRIPTION
Add functionality to display gamepad state using HTML5 gamepad API.

* **index.html**
  - Add a `canvas` element to the `body` to display gamepad state.
  - Add a `script` element to the `body` to include `gamepad.js`.

* **gamepad.js**
  - Create a function to initialize the canvas and gamepad event listeners.
  - Create a function to update the canvas with the current gamepad state.
  - Add event listeners for `gamepadconnected` and `gamepaddisconnected` events.

