### PR TITLE
Add graphical representation of gamepad sticks

### DIFF
--- a/gamepad.js
+++ b/gamepad.js
@@ -22,9 +22,10 @@ function update() {
     const gamepads = navigator.getGamepads();
     if (!gamepads) return;
 
-    gamepadContainer.innerHTML = '';
-
     let gamepadConnected = false;
+
+    // Clear previous gamepad information
+    gamepadContainer.querySelectorAll('.gamepad-info').forEach(info => info.remove());
 
     for (let i = 0; i < gamepads.length; i++) {
         const gp = gamepads[i];
@@ -56,7 +57,17 @@ function update() {
         }
         gamepadDiv.appendChild(axesDiv);
 
+        const stickContainer = document.createElement('div');
+        stickContainer.className = 'stick-container';
+        const stickCanvas = document.createElement('canvas');
+        stickCanvas.width = 300;
+        stickCanvas.height = 300;
+        stickContainer.appendChild(stickCanvas);
+        gamepadDiv.appendChild(stickContainer);
+
         gamepadContainer.appendChild(gamepadDiv);
+
+        updateStickCanvas(stickCanvas, gp.axes);
     }
 
     if (!gamepadConnected) {
@@ -66,6 +77,31 @@ function update() {
     }
 
     requestAnimationFrame(update);
+}
+
+function updateStickCanvas(canvas, axes) {
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const centerX = canvas.width / 2;
+    const centerY = canvas.height / 2;
+    const maxRadius = Math.min(centerX, centerY) - 10;
+
+    // Draw left stick
+    const leftStickX = centerX + axes[0] * maxRadius;
+    const leftStickY = centerY + axes[1] * maxRadius;
+    ctx.beginPath();
+    ctx.arc(leftStickX, leftStickY, 10, 0, 2 * Math.PI);
+    ctx.fillStyle = 'red';
+    ctx.fill();
+
+    // Draw right stick
+    const rightStickX = centerX + axes[2] * maxRadius;
+    const rightStickY = centerY + axes[3] * maxRadius;
+    ctx.beginPath();
+    ctx.arc(rightStickX, rightStickY, 10, 0, 2 * Math.PI);
+    ctx.fillStyle = 'blue';
+    ctx.fill();
 }
 
 window.onload = init;

--- a/index.html
+++ b/index.html
@@ -10,7 +10,9 @@
         <h1>Gamepad Viewer</h1>
         <p>This page displays the status of connected gamepads, including button presses and axis movements.</p>
         <div id="gamepadContainer">
-            <div class="gamepad-info"></div>
+            <div class="gamepad-info">
+                <div class="stick-container"></div>
+            </div>
             <div class="no-gamepad">No gamepad connected</div>
         </div>
         <script src="gamepad.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -65,3 +65,13 @@ p {
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+
+.stick-container {
+    width: 300px;
+    height: 300px;
+    border: 1px solid #000;
+    margin-top: 1em;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}


### PR DESCRIPTION
Add graphical representation of gamepad sticks and update gamepad information display.

* Modify `index.html` to include a `div` element with class `stick-container` inside each `gamepad-info` div.
* Add styles for the `stick-container` class in `styles.css` to ensure it is properly displayed inside the `gamepad-info` div.
* Update `gamepad.js` to create and update the stick canvas inside the `stick-container` div within each `gamepad-info` div.
* Add `updateStickCanvas` function in `gamepad.js` to draw left and right sticks on the canvas based on gamepad axes data.
* Remove the `drawStick` function and any references to it in `gamepad.js`.
* Clear previous gamepad information before updating the display in `gamepad.js`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/RyoKaringumi/gamepad-viewer/pull/4?shareId=4f2aba3e-83b3-41ca-ad7e-668160e2caf9).