### PR TITLE
Fix gamepad rendering to update only on changes

### DIFF
--- a/gamepad.js
+++ b/gamepad.js
@@ -1,5 +1,6 @@
 let gamepadContainer;
 let noGamepadMessage;
+let previousGamepadStates = [];
 
 function init() {
     gamepadContainer = document.getElementById('gamepadContainer');
@@ -24,50 +25,16 @@ function update() {
 
     let gamepadConnected = false;
 
-    // Clear previous gamepad information
-    gamepadContainer.querySelectorAll('.gamepad-info').forEach(info => info.remove());
-
     for (let i = 0; i < gamepads.length; i++) {
         const gp = gamepads[i];
         if (!gp) continue;
 
         gamepadConnected = true;
 
-        const gamepadDiv = document.createElement('div');
-        gamepadDiv.className = 'gamepad-info';
-        gamepadDiv.innerHTML = `<h2>Gamepad ${gp.index}: ${gp.id}</h2>`;
-
-        const buttonsDiv = document.createElement('div');
-        buttonsDiv.className = 'buttons-info';
-        for (let j = 0; j < gp.buttons.length; j++) {
-            const button = gp.buttons[j];
-            const buttonInfo = document.createElement('p');
-            buttonInfo.textContent = `Button ${j}: ${button.pressed}`;
-            buttonsDiv.appendChild(buttonInfo);
+        if (!previousGamepadStates[i] || !compareGamepadStates(previousGamepadStates[i], gp)) {
+            updateGamepadInfo(i, gp);
+            previousGamepadStates[i] = gp;
         }
-        gamepadDiv.appendChild(buttonsDiv);
-
-        const axesDiv = document.createElement('div');
-        axesDiv.className = 'axes-info';
-        for (let j = 0; j < gp.axes.length; j++) {
-            const axis = gp.axes[j];
-            const axisInfo = document.createElement('p');
-            axisInfo.textContent = `Axis ${j}: ${axis.toFixed(2)}`;
-            axesDiv.appendChild(axisInfo);
-        }
-        gamepadDiv.appendChild(axesDiv);
-
-        const stickContainer = document.createElement('div');
-        stickContainer.className = 'stick-container';
-        const stickCanvas = document.createElement('canvas');
-        stickCanvas.width = 300;
-        stickCanvas.height = 300;
-        stickContainer.appendChild(stickCanvas);
-        gamepadDiv.appendChild(stickContainer);
-
-        gamepadContainer.appendChild(gamepadDiv);
-
-        updateStickCanvas(stickCanvas, gp.axes);
     }
 
     if (!gamepadConnected) {
@@ -77,6 +44,68 @@ function update() {
     }
 
     requestAnimationFrame(update);
+}
+
+function updateGamepadInfo(index, gp) {
+    let gamepadDiv = document.querySelector(`.gamepad-info[data-index="${index}"]`);
+    if (!gamepadDiv) {
+        gamepadDiv = document.createElement('div');
+        gamepadDiv.className = 'gamepad-info';
+        gamepadDiv.setAttribute('data-index', index);
+        gamepadContainer.appendChild(gamepadDiv);
+    }
+
+    gamepadDiv.innerHTML = `<h2>Gamepad ${gp.index}: ${gp.id}</h2>`;
+
+    const buttonsDiv = document.createElement('div');
+    buttonsDiv.className = 'buttons-info';
+    for (let j = 0; j < gp.buttons.length; j++) {
+        const button = gp.buttons[j];
+        const buttonInfo = document.createElement('p');
+        buttonInfo.textContent = `Button ${j}: ${button.pressed}`;
+        buttonsDiv.appendChild(buttonInfo);
+    }
+    gamepadDiv.appendChild(buttonsDiv);
+
+    const axesDiv = document.createElement('div');
+    axesDiv.className = 'axes-info';
+    for (let j = 0; j < gp.axes.length; j++) {
+        const axis = gp.axes[j];
+        const axisInfo = document.createElement('p');
+        axisInfo.textContent = `Axis ${j}: ${axis.toFixed(2)}`;
+        axesDiv.appendChild(axisInfo);
+    }
+    gamepadDiv.appendChild(axesDiv);
+
+    const stickContainer = document.createElement('div');
+    stickContainer.className = 'stick-container';
+    const stickCanvas = document.createElement('canvas');
+    stickCanvas.width = 300;
+    stickCanvas.height = 300;
+    stickContainer.appendChild(stickCanvas);
+    gamepadDiv.appendChild(stickContainer);
+
+    updateStickCanvas(stickCanvas, gp.axes);
+}
+
+function compareGamepadStates(prev, curr) {
+    if (prev.buttons.length !== curr.buttons.length || prev.axes.length !== curr.axes.length) {
+        return false;
+    }
+
+    for (let i = 0; i < prev.buttons.length; i++) {
+        if (prev.buttons[i].pressed !== curr.buttons[i].pressed) {
+            return false;
+        }
+    }
+
+    for (let i = 0; i < prev.axes.length; i++) {
+        if (prev.axes[i] !== curr.axes[i]) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 function updateStickCanvas(canvas, axes) {

--- a/index.html
+++ b/index.html
@@ -10,9 +10,6 @@
         <h1>Gamepad Viewer</h1>
         <p>This page displays the status of connected gamepads, including button presses and axis movements.</p>
         <div id="gamepadContainer">
-            <div class="gamepad-info">
-                <div class="stick-container"></div>
-            </div>
             <div class="no-gamepad">No gamepad connected</div>
         </div>
         <script src="gamepad.js"></script>


### PR DESCRIPTION
Modify the `update` function in `gamepad.js` to only update changed DOM elements instead of rebuilding the entire structure.

* Add a function to compare current and previous gamepad states.
* Modify `updateStickCanvas` to only redraw when axes values change.
* Remove the initial stick display from `gamepadContainer` in `index.html`.
* Add a function `updateGamepadInfo` to handle updating gamepad information in the DOM.
* Store previous gamepad states in an array to compare with current states.

